### PR TITLE
make sure the uncancellable booking period less than 4 days

### DIFF
--- a/docs/docs/step-07.md
+++ b/docs/docs/step-07.md
@@ -148,7 +148,7 @@ Hello, I would like to cancel a booking.
 My name is Speedy McWheels. But, I don't remember the booking ID. Can you list all my future bookings?
 ```
 
-**AI**: Here are your upcoming bookings: 1. Booking ID: 1 - From: 2025-07-10 - To: 2025-07-14 2. Booking ID: 2 - From: 2025-08-05 - To: 2025-08-12 3. Booking ID: 3 - From: 2025-10-01 - To: 2025-10-07 Please let me know which booking you would like to cancel.
+**AI**: Here are your upcoming bookings: 1. Booking ID: 1 - From: 2025-07-10 - To: 2025-07-12 2. Booking ID: 2 - From: 2025-08-05 - To: 2025-08-12 3. Booking ID: 3 - From: 2025-10-01 - To: 2025-10-07 Please let me know which booking you would like to cancel.
 
 ```text title="You"
 I would like to cancel the last one.
@@ -156,7 +156,7 @@ I would like to cancel the last one.
 
 **AI**: Your booking from 2025-10-01 to 2025-10-07 has been successfully cancelled. If you need any further assistance, feel free to let me know!
 
-Here are your current bookings: 1. Booking ID: 1 - From: 2025-07-10 - To: 2025-07-14 2. Booking ID: 2 - From: 2025-08-05 - To: 2025-08-12 If you need any further assistance, please let me know!
+Here are your current bookings: 1. Booking ID: 1 - From: 2025-07-10 - To: 2025-07-12 2. Booking ID: 2 - From: 2025-08-05 - To: 2025-08-12 If you need any further assistance, please let me know!
 
 Alright, let's try now to cancel an invalid booking:
 

--- a/step-07/src/main/resources/import.sql
+++ b/step-07/src/main/resources/import.sql
@@ -6,7 +6,7 @@ INSERT INTO customer (id, firstName, lastName) VALUES (5, 'Drifty', 'Skidmark');
 
 ALTER SEQUENCE customer_seq RESTART WITH 5;
 
-INSERT INTO booking (id, customer_id, dateFrom, dateTo) VALUES (1, 1, '2025-07-10', '2025-07-14');
+INSERT INTO booking (id, customer_id, dateFrom, dateTo) VALUES (1, 1, '2025-07-10', '2025-07-12');
 INSERT INTO booking (id, customer_id, dateFrom, dateTo) VALUES (2, 1, '2025-08-05', '2025-08-12');
 INSERT INTO booking (id, customer_id, dateFrom, dateTo) VALUES (3, 1, '2025-10-01', '2025-10-07');
 


### PR DESCRIPTION
In step-07, we demonstrate that a short period booking cannot be cancelled.

However, the booking (id=1) has a period from 2025-07-10 to 2025-07-14. It's not "less than 4 days", so indeed it can be cancelled (`booking.dateTo.minusDays(4).isBefore(booking.dateFrom)` returns false). Furthermore, gpt-o4 returns unstable responses like "It can be cancelled" or "It cannot be cancelled" without using tool methods.

This PR is to make the booking period clearly less than 4 days.