### PR TITLE
Use max-segment-size in tokens in step06+ to be consistent with step05

### DIFF
--- a/docs/docs/step-06.md
+++ b/docs/docs/step-06.md
@@ -142,7 +142,7 @@ The `FileSystemDocumentLoader.loadDocumentsRecursively(documents)` method loads 
 The `EmbeddingStoreIngestor` class is used to ingest the documents into the vector store.
 This is the cornerstone of the ingestion process.
 Configuring it correctly is crucial to the accuracy of the RAG pattern.
-Here, we use a recursive document splitter with a segment size of 100 and an overlap size of 25 (like we had in the previous step).
+Here, we use a recursive document splitter with a segment size of 100 tokens and an overlap size of 25 tokens (like we had in the previous step).
 
 !!! important
     The splitter, the segment size, and the overlap size are crucial to the accuracy of the RAG pattern.

--- a/step-06/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
+++ b/step-06/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.data.document.splitter.DocumentSplitters.recursive
 import java.nio.file.Path;
 import java.util.List;
 
+import dev.langchain4j.model.embedding.onnx.HuggingFaceTokenizer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
@@ -38,7 +39,8 @@ public class RagIngestion {
         EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
                 .embeddingStore(store)
                 .embeddingModel(embeddingModel)
-                .documentSplitter(recursive(100, 25))
+                .documentSplitter(recursive(100, 25,
+                        new HuggingFaceTokenizer()))
                 .build();
         ingestor.ingest(list);
         Log.info("Documents ingested successfully");

--- a/step-07/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
+++ b/step-07/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.data.document.splitter.DocumentSplitters.recursive
 import java.nio.file.Path;
 import java.util.List;
 
+import dev.langchain4j.model.embedding.onnx.HuggingFaceTokenizer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
@@ -38,7 +39,8 @@ public class RagIngestion {
         EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
                 .embeddingStore(store)
                 .embeddingModel(embeddingModel)
-                .documentSplitter(recursive(100, 25))
+                .documentSplitter(recursive(100, 25,
+                        new HuggingFaceTokenizer()))
                 .build();
         ingestor.ingest(list);
         Log.info("Documents ingested successfully");

--- a/step-08/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
+++ b/step-08/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.data.document.splitter.DocumentSplitters.recursive
 import java.nio.file.Path;
 import java.util.List;
 
+import dev.langchain4j.model.embedding.onnx.HuggingFaceTokenizer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
@@ -38,7 +39,8 @@ public class RagIngestion {
         EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
                 .embeddingStore(store)
                 .embeddingModel(embeddingModel)
-                .documentSplitter(recursive(100, 25))
+                .documentSplitter(recursive(100, 25,
+                        new HuggingFaceTokenizer()))
                 .build();
         ingestor.ingest(list);
         Log.info("Documents ingested successfully");

--- a/step-09/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
+++ b/step-09/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.data.document.splitter.DocumentSplitters.recursive
 import java.nio.file.Path;
 import java.util.List;
 
+import dev.langchain4j.model.embedding.onnx.HuggingFaceTokenizer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
@@ -38,7 +39,8 @@ public class RagIngestion {
         EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
                 .embeddingStore(store)
                 .embeddingModel(embeddingModel)
-                .documentSplitter(recursive(100, 25))
+                .documentSplitter(recursive(100, 25,
+                        new HuggingFaceTokenizer()))
                 .build();
         ingestor.ingest(list);
         Log.info("Documents ingested successfully");

--- a/step-10/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
+++ b/step-10/src/main/java/dev/langchain4j/quarkus/workshop/RagIngestion.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.data.document.splitter.DocumentSplitters.recursive
 import java.nio.file.Path;
 import java.util.List;
 
+import dev.langchain4j.model.embedding.onnx.HuggingFaceTokenizer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
@@ -38,7 +39,8 @@ public class RagIngestion {
         EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
                 .embeddingStore(store)
                 .embeddingModel(embeddingModel)
-                .documentSplitter(recursive(100, 25))
+                .documentSplitter(recursive(100, 25,
+                        new HuggingFaceTokenizer()))
                 .build();
         ingestor.ingest(list);
         Log.info("Documents ingested successfully");


### PR DESCRIPTION
Step06+ actually uses a document splitter with a segment size of 100 **characters**, not tokens. So, it's inconsistent with step05, and 100 characters is really not enough (mostly less than one sentence)