### PR TITLE
Update sample data to remove mild toilet reference

### DIFF
--- a/step-07/src/main/resources/import.sql
+++ b/step-07/src/main/resources/import.sql
@@ -2,7 +2,7 @@ INSERT INTO customer (id, firstName, lastName) VALUES (1, 'Speedy', 'McWheels');
 INSERT INTO customer (id, firstName, lastName) VALUES (2, 'Zoom', 'Thunderfoot');
 INSERT INTO customer (id, firstName, lastName) VALUES (3, 'Vroom', 'Lightyear');
 INSERT INTO customer (id, firstName, lastName) VALUES (4, 'Turbo', 'Gearshift');
-INSERT INTO customer (id, firstName, lastName) VALUES (5, 'Drifty', 'Skidmark');
+INSERT INTO customer (id, firstName, lastName) VALUES (5, 'Drifty', 'Skiddy');
 
 ALTER SEQUENCE customer_seq RESTART WITH 5;
 

--- a/step-08/src/main/resources/import.sql
+++ b/step-08/src/main/resources/import.sql
@@ -7,7 +7,7 @@ VALUES (3, 'Vroom', 'Lightyear');
 INSERT INTO customer (id, firstName, lastName)
 VALUES (4, 'Turbo', 'Gearshift');
 INSERT INTO customer (id, firstName, lastName)
-VALUES (5, 'Drifty', 'Skidmark');
+VALUES (5, 'Drifty', 'Skiddy');
 
 ALTER SEQUENCE customer_seq RESTART WITH 5;
 

--- a/step-09/src/main/resources/import.sql
+++ b/step-09/src/main/resources/import.sql
@@ -7,7 +7,7 @@ VALUES (3, 'Vroom', 'Lightyear');
 INSERT INTO customer (id, firstName, lastName)
 VALUES (4, 'Turbo', 'Gearshift');
 INSERT INTO customer (id, firstName, lastName)
-VALUES (5, 'Drifty', 'Skidmark');
+VALUES (5, 'Drifty', 'Skiddy');
 
 ALTER SEQUENCE customer_seq RESTART WITH 5;
 

--- a/step-10/src/main/resources/import.sql
+++ b/step-10/src/main/resources/import.sql
@@ -7,7 +7,7 @@ VALUES (3, 'Vroom', 'Lightyear');
 INSERT INTO customer (id, firstName, lastName)
 VALUES (4, 'Turbo', 'Gearshift');
 INSERT INTO customer (id, firstName, lastName)
-VALUES (5, 'Drifty', 'Skidmark');
+VALUES (5, 'Drifty', 'Skiddy');
 
 ALTER SEQUENCE customer_seq RESTART WITH 5;
 


### PR DESCRIPTION
"Skidmark" is toilet-related slang in some regions. I had a mild childish snicker at it when @kdubois demoed it. Others might have the same reaction. Since there's lots of car-related words in the world we can choose one that's not distracting. Well, assuming the double meaning is not intentional, of course.