### PR TITLE
Use default langchain4j version packaged with quarkus-langchain4j for…

### DIFF
--- a/section-2/step-04/multi-agent-system/pom.xml
+++ b/section-2/step-04/multi-agent-system/pom.xml
@@ -17,9 +17,7 @@
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <quarkus-langchain4j.version>1.4.2</quarkus-langchain4j.version>
-        <langchain4j.version>1.6.0</langchain4j.version>
-        <langchain4j-beta.version>1.8.0-beta15</langchain4j-beta.version>
-        <a2a.version>0.3.3.Final</a2a.version>
+        <a2a.version>0.3.0.Beta1</a2a.version>
     </properties>
 
     <dependencyManagement>
@@ -61,7 +59,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-agentic-a2a</artifactId>
-            <version>${langchain4j-beta.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.a2asdk</groupId>

--- a/section-2/step-04/remote-a2a-agent/pom.xml
+++ b/section-2/step-04/remote-a2a-agent/pom.xml
@@ -19,8 +19,6 @@
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
         <quarkus-langchain4j.version>1.4.2</quarkus-langchain4j.version>
-        <langchain4j.version>1.6.0</langchain4j.version>
-        <langchain4j.beta.version>1.8.0-beta15</langchain4j.beta.version>
         <a2a.version>0.3.0.Beta1</a2a.version>
     </properties>
 
@@ -59,12 +57,11 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-agentic-a2a</artifactId>
-            <version>${langchain4j.beta.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.a2asdk</groupId>
             <artifactId>a2a-java-sdk-reference-jsonrpc</artifactId>
-            <version>0.3.3.Final</version>
+            <version>${a2a.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
no more need for the 1.8.0 beta version.