### PR TITLE
Fix quarkus-junit relocation

### DIFF
--- a/section-1/step-08-mcp-server/pom.xml
+++ b/section-1/step-08-mcp-server/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/section-2/step-01/pom.xml
+++ b/section-2/step-01/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/section-2/step-02/pom.xml
+++ b/section-2/step-02/pom.xml
@@ -62,7 +62,7 @@
         
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/section-2/step-03/pom.xml
+++ b/section-2/step-03/pom.xml
@@ -67,7 +67,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/section-2/step-04/pom.xml
+++ b/section-2/step-04/pom.xml
@@ -67,7 +67,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/section-2/step-05/multi-agent-system/pom.xml
+++ b/section-2/step-05/multi-agent-system/pom.xml
@@ -75,7 +75,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/section-2/step-06/pom.xml
+++ b/section-2/step-06/pom.xml
@@ -76,7 +76,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Since `quarkus-junit5` was relocated to `quarkus-junit` `artifactId`, I have updated its references. 