### PR TITLE
Fix step-08: Change return type from String to Multi<String> for stre…

### DIFF
--- a/docs/docs/section-1/step-08.md
+++ b/docs/docs/section-1/step-08.md
@@ -104,6 +104,9 @@ We'll add a `@McpToolBox("weather")` annotation to our AI Service to reference t
 --8<-- "../../section-1/step-08/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgent.java"
 ```
 
+!!! note
+    Note that the `chat` method returns `Multi<String>` to support streaming responses, as introduced in [Step 04](./step-04.md). This streaming pattern is maintained throughout the workshop, including when using MCP tools.
+
 ## Testing the function calling
 
 Let's test the function calling.

--- a/section-1/step-08/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgent.java
+++ b/section-1/step-08/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgent.java
@@ -6,6 +6,7 @@ import jakarta.enterprise.context.SessionScoped;
 import dev.langchain4j.service.SystemMessage;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.ToolBox;
+import io.smallrye.mutiny.Multi;
 
 @SessionScoped
 @RegisterAiService
@@ -14,7 +15,7 @@ public interface CustomerSupportAgent {
     @SystemMessage("""
             You are a customer support agent of a car rental company 'Miles of Smiles'.
             You are friendly, polite and concise.
-            If the question is unrelated to car rental, you should politely redirect 
+            If the question is unrelated to car rental, you should politely redirect
             the customer to the right department.
             
             When calling tools or functions, strictly use JSON objects,
@@ -24,5 +25,5 @@ public interface CustomerSupportAgent {
             """)
     @ToolBox(BookingRepository.class)
     @McpToolBox("weather")
-    String chat(String userMessage);
+    Multi<String> chat(String userMessage);
 }

--- a/section-1/step-08/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgentWebSocket.java
+++ b/section-1/step-08/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgentWebSocket.java
@@ -3,6 +3,7 @@ package dev.langchain4j.quarkus.workshop;
 import io.quarkus.websockets.next.OnOpen;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.WebSocket;
+import io.smallrye.mutiny.Multi;
 
 @WebSocket(path = "/customer-support-agent")
 public class CustomerSupportAgentWebSocket {
@@ -19,7 +20,7 @@ public class CustomerSupportAgentWebSocket {
     }
     // --8<-- [start:tools]
     @OnTextMessage
-    public String onTextMessage(String message) {
+    public Multi<String> onTextMessage(String message) {
         return customerSupportAgent.chat(message);
     }
     // --8<-- [end:tools]


### PR DESCRIPTION
…aming support

- Updated CustomerSupportAgent.chat() to return Multi<String> instead of String
- Updated CustomerSupportAgentWebSocket.onTextMessage() to return Multi<String>
- Added missing import for io.smallrye.mutiny.Multi in both files
- This fixes the type mismatch compilation error when using MCP tools

The change aligns step-08 with the streaming pattern used in earlier steps (step-04, step-05) and ensures proper WebSocket streaming functionality when calling MCP servers.