### PR TITLE
Bump Quarkus to 3.37.2 and quarkus-langchain4j to 1.12.0 + Introduce new @Skills annotation

### DIFF
--- a/docs/docs/section-3/step-01.md
+++ b/docs/docs/section-3/step-01.md
@@ -21,8 +21,7 @@ In this step, you will:
 - Build a **multi-agent system** that splits trip planning across specialized agents
 - Use `@SequenceAgent` and `@ParallelAgent` to orchestrate agents into a **pipeline with parallel phases**
 - Use `@Output` to **assemble results** from the `AgenticScope` into a final response
-- Use `SkillsToolProvider` to **dynamically load expertise** from Markdown files on the filesystem
-- Use `@SystemMessageProviderSupplier` to **inject skill knowledge** into specific agents at runtime
+- Use `@Skills` to **dynamically inject expertise** from Markdown skill files into specific agents at runtime
 - Use `MonitoredAgent` for **built-in observability** across the entire agent pipeline
 
 ---
@@ -118,7 +117,7 @@ You are an expert at planning adventurous road trips across Europe...
 - Recommend vehicles with good ground clearance...
 ```
 
-The `quarkus-langchain4j-skills` extension scans one or more directories and makes all discovered skills available to agents via a `SkillsToolProvider` CDI bean. The directories to scan are configured in `application.properties` using the `quarkus.langchain4j.skills.directories` property — each entry can be a filesystem path or a classpath location (prefixed with `classpath:`). See the [Skills extension documentation](https://docs.quarkiverse.io/quarkus-langchain4j/dev/skills.html#_configuration){target="_blank"} for full configuration details. The agent can then inject this knowledge into its system message dynamically.
+The `quarkus-langchain4j-skills` extension scans one or more directories and makes all discovered skills available to agents. The directories to scan are configured in `application.properties` using the `quarkus.langchain4j.skills.directories` property — each entry can be a filesystem path or a classpath location (prefixed with `classpath:`). See the [Skills extension documentation](https://docs.quarkiverse.io/quarkus-langchain4j/dev/skills.html#_configuration){target="_blank"} for full configuration details. Agents annotated with `@Skills` automatically get access to the available skills, allowing the LLM to activate the most relevant ones for each request.
 
 **Benefits of this approach:**
 
@@ -227,9 +226,9 @@ Open the `pom.xml` file. The key dependencies for this step are:
 </dependency>
 ```
 
-- `quarkus-langchain4j-agentic`: The agent framework with `@Agent`, `@SequenceAgent`, `@ParallelAgent`, `@SystemMessageProviderSupplier`, and workflow support
+- `quarkus-langchain4j-agentic`: The agent framework with `@Agent`, `@SequenceAgent`, `@ParallelAgent`, and workflow support
 - `quarkus-langchain4j-openai`: OpenAI model provider (GPT-4o)
-- `quarkus-langchain4j-skills`: The skills extension that loads `SKILL.md` files and provides `SkillsToolProvider`
+- `quarkus-langchain4j-skills`: The skills extension that loads `SKILL.md` files and provides the `@Skills` annotation
 
 ---
 
@@ -247,7 +246,7 @@ The trip planning work is split across four specialized AI agents. Each agent ha
 
 - `outputKey = "vehicle"` — the recommended vehicle is stored in scope under this key, so downstream agents can read it
 - Returns `TripPlan.VehicleRecommendation` — a nested record with `type`, `model`, and `reasoning`
-- Has `@SystemMessageProviderSupplier` to load skills — the `adventure-trip` skill recommends 4WD vehicles while the `family-trip` skill recommends spacious MPVs
+- Has `@Skills` to load skills — the `adventure-trip` skill recommends 4WD vehicles while the `family-trip` skill recommends spacious MPVs
 - Does **not** receive `days` — vehicle selection doesn't depend on trip duration
 
 ### ItineraryPlannerAgent — Planning the Route
@@ -259,7 +258,7 @@ The trip planning work is split across four specialized AI agents. Each agent ha
 **Key points:**
 
 - `outputKey = "itineraryResult"` — stores an `ItineraryResult` (route overview + list of day itineraries) in scope
-- Also has `@SystemMessageProviderSupplier` for skills — the `adventure-trip` skill suggests legendary driving roads like Stelvio Pass, while the `family-trip` skill recommends kid-friendly stops every 2-3 hours
+- Also has `@Skills` for skills — the `adventure-trip` skill suggests legendary driving roads like Stelvio Pass, while the `family-trip` skill recommends kid-friendly stops every 2-3 hours
 - Does **not** receive `travelers` or `budget` — those are cost concerns, not route planning concerns
 
 !!! note "Why ItineraryResult instead of separate fields?"
@@ -373,7 +372,7 @@ The application ships with three skill files in `src/main/resources/skills/`:
 
 Each skill follows the same structure:
 
-- **YAML frontmatter**: `name` and `description` — used by `SkillsToolProvider` to index and present skills
+- **YAML frontmatter**: `name` and `description` — used by the skills extension to index and present skills to the LLM
 - **Markdown body**: The actual expertise — vehicle recommendations, route planning guidelines, accommodation tips, and practical considerations
 
 The other two skills (`adventure-trip/SKILL.md` and `business-trip/SKILL.md`) follow the same pattern with expertise tailored to their trip types.
@@ -412,7 +411,6 @@ sequenceDiagram
     participant Seq as TripPlannerSystem
     participant VA as VehicleAdvisorAgent
     participant IP as ItineraryPlannerAgent
-    participant Skills as SkillsToolProvider
     participant LLM as OpenAI GPT-4o
     participant CE as CostEstimatorAgent
     participant TG as TipsGeneratorAgent
@@ -422,15 +420,15 @@ sequenceDiagram
 
     Note over Seq: Step 1: Parallel Research
     par VehicleAdvisorAgent
-        VA->>Skills: Load skills
-        Skills-->>VA: family-trip, adventure-trip, business-trip
+        Note over VA: @Skills loads available skills
         VA->>LLM: "Recommend a vehicle for a family trip..."
+        Note over LLM: activates family-trip skill
         LLM-->>VA: {type: "MPV", model: "VW Multivan", reasoning: "..."}
         Note over VA: → scope["vehicle"]
     and ItineraryPlannerAgent
-        IP->>Skills: Load skills
-        Skills-->>IP: family-trip, adventure-trip, business-trip
+        Note over IP: @Skills loads available skills
         IP->>LLM: "Plan a 5-day itinerary for the Italian Riviera..."
+        Note over LLM: activates family-trip skill
         LLM-->>IP: {routeOverview: "...", itinerary: [{day: 1, ...}, ...]}
         Note over IP: → scope["itineraryResult"]
     end
@@ -452,7 +450,7 @@ sequenceDiagram
 
 **Key Points:**
 
-1. `VehicleAdvisorAgent` and `ItineraryPlannerAgent` run **in parallel** inside `ResearchPhase` — both load skills via `@SystemMessageProviderSupplier`
+1. `VehicleAdvisorAgent` and `ItineraryPlannerAgent` run **in parallel** inside `ResearchPhase` — both load skills via `@Skills`
 2. `CostEstimatorAgent` runs after the research phase, reading the vehicle and itinerary from scope
 3. `TipsGeneratorAgent` runs last, with access to all prior results
 4. The `@Output` method on `TripPlannerSystem` assembles all outputs into a `TripPlan` with pure Java — no LLM call wasted on data assembly
@@ -472,7 +470,7 @@ Notice how `recommendVehicle` and `planItinerary` run in parallel (overlapping t
 - **AgenticScope**: Agents exchange data through a shared scope — each agent writes its output under an `outputKey` and reads inputs by parameter name
 - **`@Output` for assembly**: The `@Output` static method on a workflow reads sub-agent results from the scope and combines them into a final return value — pure Java, no LLM call wasted on data assembly
 - **Skills externalize expertise**: Domain knowledge lives in Markdown files, not in code — making agents modular and extensible
-- **Dynamic system messages**: `@SystemMessageProviderSupplier` builds the agent's context at runtime, picking up new skills without recompilation
+- **Dynamic skill injection**: `@Skills` injects skill knowledge into an agent at runtime, picking up new skills without recompilation
 - **Structured output**: Returning record types (`VehicleRecommendation`, `ItineraryResult`, `CostEstimate`) gives you type-safe, well-structured responses from each agent
 - **Built-in observability**: Extending `MonitoredAgent` gives you a full invocation tree with timing, token counts, and inputs/outputs across all sub-agents — no extra wiring needed
 - **Transparent orchestration**: The REST layer is unaware of the multi-agent architecture — composition happens inside the agent framework
@@ -540,7 +538,7 @@ Look at the LLM requests in the logs. Notice how each agent's prompt is **smalle
     - Verify that `quarkus.langchain4j.skills.directories=classpath:skills` is set in `application.properties`
     - Check that skill files are named `SKILL.md` (case-sensitive) and placed in subdirectories under `src/main/resources/skills/`
     - Each `SKILL.md` must have valid YAML frontmatter with `name` and `description` fields
-    - Only `VehicleAdvisorAgent` and `ItineraryPlannerAgent` load skills — the other agents don't use `@SystemMessageProviderSupplier`
+    - Only `VehicleAdvisorAgent` and `ItineraryPlannerAgent` load skills — the other agents don't use `@Skills`
 
 ---
 

--- a/section-1/step-01/pom.xml
+++ b/section-1/step-01/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-1/step-02/pom.xml
+++ b/section-1/step-02/pom.xml
@@ -17,8 +17,8 @@
 
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-1/step-03/pom.xml
+++ b/section-1/step-03/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-1/step-04/pom.xml
+++ b/section-1/step-04/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-1/step-05/pom.xml
+++ b/section-1/step-05/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-1/step-06/pom.xml
+++ b/section-1/step-06/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-1/step-07/pom.xml
+++ b/section-1/step-07/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-1/step-08-mcp-server/pom.xml
+++ b/section-1/step-08-mcp-server/pom.xml
@@ -17,9 +17,9 @@
 
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
 
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
 
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>

--- a/section-1/step-08/pom.xml
+++ b/section-1/step-08/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-1/step-09/pom.xml
+++ b/section-1/step-09/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-1/step-10/pom.xml
+++ b/section-1/step-10/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-1/step-11/pom.xml
+++ b/section-1/step-11/pom.xml
@@ -16,8 +16,8 @@
 
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
 
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
         <jlama.version>0.8.4</jlama.version>
     </properties>
 

--- a/section-2/step-01/pom.xml
+++ b/section-2/step-01/pom.xml
@@ -12,10 +12,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-2/step-02/pom.xml
+++ b/section-2/step-02/pom.xml
@@ -13,10 +13,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-2/step-03/pom.xml
+++ b/section-2/step-03/pom.xml
@@ -13,10 +13,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-2/step-04/pom.xml
+++ b/section-2/step-04/pom.xml
@@ -13,10 +13,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-2/step-05/pom.xml
+++ b/section-2/step-05/pom.xml
@@ -13,10 +13,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-2/step-06/pom.xml
+++ b/section-2/step-06/pom.xml
@@ -13,10 +13,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-2/step-07/multi-agent-system/pom.xml
+++ b/section-2/step-07/multi-agent-system/pom.xml
@@ -13,10 +13,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-2/step-07/remote-a2a-agent/pom.xml
+++ b/section-2/step-07/remote-a2a-agent/pom.xml
@@ -15,10 +15,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
         <a2a.version>1.0.0.Final</a2a.version>
     </properties>
 

--- a/section-2/step-08/multi-agent-system/pom.xml
+++ b/section-2/step-08/multi-agent-system/pom.xml
@@ -12,10 +12,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-2/step-08/remote-a2a-agent/pom.xml
+++ b/section-2/step-08/remote-a2a-agent/pom.xml
@@ -14,10 +14,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
         <a2a.version>1.0.0.Final</a2a.version>
     </properties>
 

--- a/section-3/step-01/pom.xml
+++ b/section-3/step-01/pom.xml
@@ -12,10 +12,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-3/step-01/src/main/java/com/tripplanner/agentic/agents/ItineraryPlannerAgent.java
+++ b/section-3/step-01/src/main/java/com/tripplanner/agentic/agents/ItineraryPlannerAgent.java
@@ -2,11 +2,8 @@ package com.tripplanner.agentic.agents;
 
 import com.tripplanner.model.ItineraryResult;
 import dev.langchain4j.agentic.Agent;
-import dev.langchain4j.agentic.declarative.SystemMessageProviderSupplier;
 import dev.langchain4j.service.UserMessage;
-import io.quarkiverse.langchain4j.skills.runtime.SkillsToolProvider;
-import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.spi.CDI;
+import io.quarkiverse.langchain4j.skills.Skills;
 
 public interface ItineraryPlannerAgent {
 
@@ -22,20 +19,9 @@ public interface ItineraryPlannerAgent {
             """)
     @Agent(description = "Creates a detailed day-by-day itinerary and route overview",
            outputKey = "itineraryResult")
+    @Skills
     ItineraryResult planItinerary(String destination,
                                   Integer days,
                                   String tripType,
                                   String preferences);
-
-    @SystemMessageProviderSupplier
-    static String systemMessageProvider(Object memoryId) {
-        Instance<SkillsToolProvider> skillsToolProvider = CDI.current().select(SkillsToolProvider.class);
-        if (skillsToolProvider.isResolvable()) {
-            return """
-                    You have access to the following skills:
-                    %s
-                    """.formatted(skillsToolProvider.get().getSkills().formatAvailableSkills());
-        }
-        return "";
-    }
 }

--- a/section-3/step-01/src/main/java/com/tripplanner/agentic/agents/VehicleAdvisorAgent.java
+++ b/section-3/step-01/src/main/java/com/tripplanner/agentic/agents/VehicleAdvisorAgent.java
@@ -2,11 +2,8 @@ package com.tripplanner.agentic.agents;
 
 import com.tripplanner.model.TripPlan;
 import dev.langchain4j.agentic.Agent;
-import dev.langchain4j.agentic.declarative.SystemMessageProviderSupplier;
 import dev.langchain4j.service.UserMessage;
-import io.quarkiverse.langchain4j.skills.runtime.SkillsToolProvider;
-import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.spi.CDI;
+import io.quarkiverse.langchain4j.skills.Skills;
 
 public interface VehicleAdvisorAgent {
 
@@ -23,21 +20,10 @@ public interface VehicleAdvisorAgent {
             """)
     @Agent(description = "Recommends the best vehicle for the trip based on destination, travelers, and budget",
            outputKey = "vehicle")
+    @Skills
     TripPlan.VehicleRecommendation recommendVehicle(String destination,
                                                     String tripType,
                                                     Integer travelers,
                                                     String budget,
                                                     String preferences);
-
-    @SystemMessageProviderSupplier
-    static String systemMessageProvider(Object memoryId) {
-        Instance<SkillsToolProvider> skillsToolProvider = CDI.current().select(SkillsToolProvider.class);
-        if (skillsToolProvider.isResolvable()) {
-            return """
-                    You have access to the following skills:
-                    %s
-                    """.formatted(skillsToolProvider.get().getSkills().formatAvailableSkills());
-        }
-        return "";
-    }
 }

--- a/section-3/step-02/pom.xml
+++ b/section-3/step-02/pom.xml
@@ -12,10 +12,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.0</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
-        <quarkus-langchain4j.version>1.12.0.CR2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>1.12.0</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/section-3/step-02/src/main/java/com/tripplanner/agentic/agents/ItineraryPlannerAgent.java
+++ b/section-3/step-02/src/main/java/com/tripplanner/agentic/agents/ItineraryPlannerAgent.java
@@ -3,12 +3,9 @@ package com.tripplanner.agentic.agents;
 import com.tripplanner.guardrails.TripSafetyGuardrail;
 import com.tripplanner.model.ItineraryResult;
 import dev.langchain4j.agentic.Agent;
-import dev.langchain4j.agentic.declarative.SystemMessageProviderSupplier;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.guardrail.OutputGuardrails;
-import io.quarkiverse.langchain4j.skills.runtime.SkillsToolProvider;
-import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.spi.CDI;
+import io.quarkiverse.langchain4j.skills.Skills;
 
 public interface ItineraryPlannerAgent {
 
@@ -25,20 +22,9 @@ public interface ItineraryPlannerAgent {
     @Agent(description = "Creates a detailed day-by-day itinerary and route overview",
            outputKey = "itineraryResult")
     @OutputGuardrails(value = TripSafetyGuardrail.class, maxRetries = 3)
+    @Skills
     ItineraryResult planItinerary(String destination,
                                   Integer days,
                                   String tripType,
                                   String preferences);
-
-    @SystemMessageProviderSupplier
-    static String systemMessageProvider(Object memoryId) {
-        Instance<SkillsToolProvider> skillsToolProvider = CDI.current().select(SkillsToolProvider.class);
-        if (skillsToolProvider.isResolvable()) {
-            return """
-                    You have access to the following skills:
-                    %s
-                    """.formatted(skillsToolProvider.get().getSkills().formatAvailableSkills());
-        }
-        return "";
-    }
 }

--- a/section-3/step-02/src/main/java/com/tripplanner/agentic/agents/VehicleAdvisorAgent.java
+++ b/section-3/step-02/src/main/java/com/tripplanner/agentic/agents/VehicleAdvisorAgent.java
@@ -3,12 +3,9 @@ package com.tripplanner.agentic.agents;
 import com.tripplanner.guardrails.TripAppropriatenessGuardrail;
 import com.tripplanner.model.TripPlan;
 import dev.langchain4j.agentic.Agent;
-import dev.langchain4j.agentic.declarative.SystemMessageProviderSupplier;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.guardrail.OutputGuardrails;
-import io.quarkiverse.langchain4j.skills.runtime.SkillsToolProvider;
-import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.spi.CDI;
+import io.quarkiverse.langchain4j.skills.Skills;
 
 public interface VehicleAdvisorAgent {
 
@@ -26,21 +23,10 @@ public interface VehicleAdvisorAgent {
     @Agent(description = "Recommends the best vehicle for the trip based on destination, travelers, and budget",
            outputKey = "vehicle")
     @OutputGuardrails(value = TripAppropriatenessGuardrail.class, maxRetries = 3)
+    @Skills
     TripPlan.VehicleRecommendation recommendVehicle(String destination,
                                                     String tripType,
                                                     Integer travelers,
                                                     String budget,
                                                     String preferences);
-
-    @SystemMessageProviderSupplier
-    static String systemMessageProvider(Object memoryId) {
-        Instance<SkillsToolProvider> skillsToolProvider = CDI.current().select(SkillsToolProvider.class);
-        if (skillsToolProvider.isResolvable()) {
-            return """
-                    You have access to the following skills:
-                    %s
-                    """.formatted(skillsToolProvider.get().getSkills().formatAvailableSkills());
-        }
-        return "";
-    }
 }


### PR DESCRIPTION
I believe it would be a good idea to also split the existing skills and have some of them specific for the vehicle selection, so we could demonstrate how the `@Skills` annotation also allows to select only a subset of all available skills.

@kdubois If you agree with this, can you please take care of it will restructuring the documentation?