### PR TITLE
Don't retry/fallback on InputGuardrailException

### DIFF
--- a/section-1/step-10/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgent.java
+++ b/section-1/step-10/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgent.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.quarkus.workshop;
 
+import dev.langchain4j.guardrail.InputGuardrailException;
 import dev.langchain4j.service.guardrail.InputGuardrails;
 import io.quarkiverse.langchain4j.mcp.runtime.McpToolBox;
 import jakarta.enterprise.context.SessionScoped;
@@ -35,8 +36,8 @@ public interface CustomerSupportAgent {
     @ToolBox(BookingRepository.class)
     @McpToolBox("weather")
     @Timeout(5000)
-    @Retry(maxRetries = 3, delay = 100)
-    @Fallback(CustomerSupportAgentFallback.class)
+    @Retry(maxRetries = 3, delay = 100, abortOn = InputGuardrailException.class)
+    @Fallback(value = CustomerSupportAgentFallback.class, skipOn = InputGuardrailException.class)
     String chat(String userMessage);
 
     public static class CustomerSupportAgentFallback implements FallbackHandler<String> {

--- a/section-1/step-11/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgent.java
+++ b/section-1/step-11/src/main/java/dev/langchain4j/quarkus/workshop/CustomerSupportAgent.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.quarkus.workshop;
 
+import dev.langchain4j.guardrail.InputGuardrailException;
 import dev.langchain4j.service.guardrail.InputGuardrails;
 import jakarta.enterprise.context.SessionScoped;
 
@@ -30,8 +31,8 @@ public interface CustomerSupportAgent {
     @InputGuardrails(PromptInjectionGuard.class)
 //    @ToolBox(BookingRepository.class)
     @Timeout(120000)
-    @Retry(maxRetries = 3, delay = 100)
-    @Fallback(CustomerSupportAgentFallback.class)
+    @Retry(maxRetries = 3, delay = 100, abortOn = InputGuardrailException.class)
+    @Fallback(value = CustomerSupportAgentFallback.class, skipOn = InputGuardrailException.class)
     String chat(String userMessage);
 
     public static class CustomerSupportAgentFallback implements FallbackHandler<String> {


### PR DESCRIPTION
First of all, thank you for the workshop. I've been learning a lot about Quarkus and Langchain4j.

This PR prevents `InputGuardrailException` from being retried and handled by the fallback mechanism. This fix ensures that guardrail exceptions can propagate normally to the intended error handling in `CustomerSupportAgentWebSocket` instead of being retried 3 times and eventually handled by `CustomerSupportAgentFallback`. 