### PR TITLE
fix(section-2): prevent concurrent return race condition and stale approval modal

### DIFF
--- a/section-2/step-01/src/main/resources/META-INF/resources/js/app.js
+++ b/section-2/step-01/src/main/resources/META-INF/resources/js/app.js
@@ -7,6 +7,7 @@ let carsData = []; // Store the cars data globally for sorting
 let currentFilterText = '';
 let currentFilterField = 'all';
 let lastUpdatedCarId = null; // Track the last updated car for highlighting
+let processingCarIds = new Set(); // Track cars currently being processed
 
 // Wait for the DOM to be fully loaded
 document.addEventListener('DOMContentLoaded', function() {
@@ -182,11 +183,12 @@ function populateFleetStatusTable(cars) {
         // Build action column based on status
         let actionCell = '<td></td>';
         if (car.status === 'RENTED' || car.status === 'AT_CLEANING') {
+            const isProcessing = processingCarIds.has(car.id);
             actionCell = `
                 <td>
                     <form onsubmit="processFeedback(event, ${car.id}, '${car.status}')">
-                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback">
-                        <button type="submit" class="return-button">Return</button>
+                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback" ${isProcessing ? 'disabled' : ''}>
+                        <button type="submit" class="return-button" ${isProcessing ? 'disabled' : ''}>${isProcessing ? 'Processing...' : 'Return'}</button>
                     </form>
                 </td>
             `;
@@ -208,12 +210,15 @@ function populateFleetStatusTable(cars) {
 // Function to process feedback and return a car
 function processFeedback(event, carId, status) {
     event.preventDefault();
+
+    if (processingCarIds.has(carId)) return;
+
     const feedback = document.getElementById(`feedback-${carId}`).value;
     const button = event.target.querySelector('button');
 
+    processingCarIds.add(carId);
     button.disabled = true;
     button.classList.add('loading');
-    const originalText = button.textContent;
     button.textContent = 'Processing...';
 
     const statusLabels = {
@@ -227,6 +232,7 @@ function processFeedback(event, carId, status) {
         return response.text();
     })
     .then(data => {
+        processingCarIds.delete(carId);
         lastUpdatedCarId = carId;
         showNotification(`Car successfully returned from ${statusLabels[status]}`);
         loadAllCars();
@@ -234,9 +240,8 @@ function processFeedback(event, carId, status) {
     .catch(error => {
         console.error(`Error returning car from ${statusLabels[status]}:`, error);
         displayError(`Failed to process ${statusLabels[status]} return. Please try again.`);
-        button.disabled = false;
-        button.classList.remove('loading');
-        button.textContent = originalText;
+        processingCarIds.delete(carId);
+        loadAllCars();
     });
 }
 

--- a/section-2/step-02/src/main/resources/META-INF/resources/js/app.js
+++ b/section-2/step-02/src/main/resources/META-INF/resources/js/app.js
@@ -7,6 +7,7 @@ let carsData = []; // Store the cars data globally for sorting
 let currentFilterText = '';
 let currentFilterField = 'all';
 let lastUpdatedCarId = null; // Track the last updated car for highlighting
+let processingCarIds = new Set(); // Track cars currently being processed
 
 // Wait for the DOM to be fully loaded
 document.addEventListener('DOMContentLoaded', function() {
@@ -183,11 +184,12 @@ function populateFleetStatusTable(cars) {
         // Build action column based on status
         let actionCell = '<td></td>';
         if (car.status === 'RENTED' || car.status === 'AT_CLEANING') {
+            const isProcessing = processingCarIds.has(car.id);
             actionCell = `
                 <td>
                     <form onsubmit="processFeedback(event, ${car.id}, '${car.status}')">
-                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback">
-                        <button type="submit" class="return-button">Return</button>
+                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback" ${isProcessing ? 'disabled' : ''}>
+                        <button type="submit" class="return-button" ${isProcessing ? 'disabled' : ''}>${isProcessing ? 'Processing...' : 'Return'}</button>
                     </form>
                 </td>
             `;
@@ -210,12 +212,15 @@ function populateFleetStatusTable(cars) {
 // Function to process feedback and return a car
 function processFeedback(event, carId, status) {
     event.preventDefault();
+
+    if (processingCarIds.has(carId)) return;
+
     const feedback = document.getElementById(`feedback-${carId}`).value;
     const button = event.target.querySelector('button');
 
+    processingCarIds.add(carId);
     button.disabled = true;
     button.classList.add('loading');
-    const originalText = button.textContent;
     button.textContent = 'Processing...';
 
     const statusLabels = {
@@ -229,6 +234,7 @@ function processFeedback(event, carId, status) {
         return response.text();
     })
     .then(data => {
+        processingCarIds.delete(carId);
         lastUpdatedCarId = carId;
         showNotification(`Car successfully returned from ${statusLabels[status]}`);
         loadAllCars();
@@ -236,9 +242,8 @@ function processFeedback(event, carId, status) {
     .catch(error => {
         console.error(`Error returning car from ${statusLabels[status]}:`, error);
         displayError(`Failed to process ${statusLabels[status]} return. Please try again.`);
-        button.disabled = false;
-        button.classList.remove('loading');
-        button.textContent = originalText;
+        processingCarIds.delete(carId);
+        loadAllCars();
     });
 }
 

--- a/section-2/step-03/src/main/resources/META-INF/resources/js/app.js
+++ b/section-2/step-03/src/main/resources/META-INF/resources/js/app.js
@@ -7,6 +7,7 @@ let carsData = []; // Store the cars data globally for sorting
 let currentFilterText = '';
 let currentFilterField = 'all';
 let lastUpdatedCarId = null; // Track the last updated car for highlighting
+let processingCarIds = new Set(); // Track cars currently being processed
 
 // Wait for the DOM to be fully loaded
 document.addEventListener('DOMContentLoaded', function() {
@@ -183,11 +184,12 @@ function populateFleetStatusTable(cars) {
         // Build action cell based on status
         let actionCell = '<td></td>';
         if (car.status === 'RENTED' || car.status === 'AT_CLEANING' || car.status === 'IN_MAINTENANCE') {
+            const isProcessing = processingCarIds.has(car.id);
             actionCell = `
                 <td>
                     <form onsubmit="processFeedback(event, ${car.id}, '${car.status}')">
-                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback">
-                        <button type="submit" class="return-button">Return</button>
+                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback" ${isProcessing ? 'disabled' : ''}>
+                        <button type="submit" class="return-button" ${isProcessing ? 'disabled' : ''}>${isProcessing ? 'Processing...' : 'Return'}</button>
                     </form>
                 </td>`;
         }
@@ -209,12 +211,15 @@ function populateFleetStatusTable(cars) {
 // Function to process feedback and return a car
 function processFeedback(event, carId, status) {
     event.preventDefault();
+
+    if (processingCarIds.has(carId)) return;
+
     const feedback = document.getElementById(`feedback-${carId}`).value;
     const button = event.target.querySelector('button');
 
+    processingCarIds.add(carId);
     button.disabled = true;
     button.classList.add('loading');
-    const originalText = button.textContent;
     button.textContent = 'Processing...';
 
     const statusLabels = {
@@ -229,6 +234,7 @@ function processFeedback(event, carId, status) {
         return response.text();
     })
     .then(data => {
+        processingCarIds.delete(carId);
         lastUpdatedCarId = carId;
         showNotification(`Car successfully returned from ${statusLabels[status]}`);
         loadAllCars();
@@ -236,9 +242,8 @@ function processFeedback(event, carId, status) {
     .catch(error => {
         console.error(`Error returning car from ${statusLabels[status]}:`, error);
         displayError(`Failed to process ${statusLabels[status]} return. Please try again.`);
-        button.disabled = false;
-        button.classList.remove('loading');
-        button.textContent = originalText;
+        processingCarIds.delete(carId);
+        loadAllCars();
     });
 }
 

--- a/section-2/step-04/src/main/resources/META-INF/resources/js/app.js
+++ b/section-2/step-04/src/main/resources/META-INF/resources/js/app.js
@@ -7,6 +7,7 @@ let carsData = []; // Store the cars data globally for sorting
 let currentFilterText = '';
 let currentFilterField = 'all';
 let lastUpdatedCarId = null; // Track the last updated car for highlighting
+let processingCarIds = new Set(); // Track cars currently being processed
 
 // Wait for the DOM to be fully loaded
 document.addEventListener('DOMContentLoaded', function() {
@@ -183,11 +184,12 @@ function populateFleetStatusTable(cars) {
         // Build action cell based on status
         let actionCell = '';
         if (car.status === 'RENTED' || car.status === 'AT_CLEANING' || car.status === 'IN_MAINTENANCE') {
+            const isProcessing = processingCarIds.has(car.id);
             actionCell = `
                 <td>
                     <form onsubmit="processFeedback(event, ${car.id}, '${car.status}')">
-                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback">
-                        <button type="submit" class="return-button">Return</button>
+                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback" ${isProcessing ? 'disabled' : ''}>
+                        <button type="submit" class="return-button" ${isProcessing ? 'disabled' : ''}>${isProcessing ? 'Processing...' : 'Return'}</button>
                     </form>
                 </td>`;
         } else {
@@ -211,12 +213,15 @@ function populateFleetStatusTable(cars) {
 // Function to process feedback and return a car
 function processFeedback(event, carId, status) {
     event.preventDefault();
+
+    if (processingCarIds.has(carId)) return;
+
     const feedback = document.getElementById(`feedback-${carId}`).value;
     const button = event.target.querySelector('button');
 
+    processingCarIds.add(carId);
     button.disabled = true;
     button.classList.add('loading');
-    const originalText = button.textContent;
     button.textContent = 'Processing...';
 
     const statusLabels = {
@@ -231,6 +236,7 @@ function processFeedback(event, carId, status) {
         return response.text();
     })
     .then(data => {
+        processingCarIds.delete(carId);
         lastUpdatedCarId = carId;
         showNotification(`Car successfully returned from ${statusLabels[status]}`);
         loadAllCars();
@@ -238,9 +244,8 @@ function processFeedback(event, carId, status) {
     .catch(error => {
         console.error(`Error returning car from ${statusLabels[status]}:`, error);
         displayError(`Failed to process ${statusLabels[status]} return. Please try again.`);
-        button.disabled = false;
-        button.classList.remove('loading');
-        button.textContent = originalText;
+        processingCarIds.delete(carId);
+        loadAllCars();
     });
 }
 

--- a/section-2/step-05/src/main/resources/META-INF/resources/js/app.js
+++ b/section-2/step-05/src/main/resources/META-INF/resources/js/app.js
@@ -7,6 +7,7 @@ let carsData = []; // Store the cars data globally for sorting
 let currentFilterText = '';
 let currentFilterField = 'all';
 let lastUpdatedCarId = null; // Track the last updated car for highlighting
+let processingCarIds = new Set(); // Track cars currently being processed
 
 // Wait for the DOM to be fully loaded
 document.addEventListener('DOMContentLoaded', function() {
@@ -185,11 +186,12 @@ function populateFleetStatusTable(cars) {
         
         let actionCell = '';
         if (car.status === 'RENTED' || car.status === 'AT_CLEANING' || car.status === 'IN_MAINTENANCE') {
+            const isProcessing = processingCarIds.has(car.id);
             actionCell = `
                 <td>
                     <form onsubmit="processFeedback(event, ${car.id}, '${car.status}')">
-                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback">
-                        <button type="submit" class="return-button">Return</button>
+                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback" ${isProcessing ? 'disabled' : ''}>
+                        <button type="submit" class="return-button" ${isProcessing ? 'disabled' : ''}>${isProcessing ? 'Processing...' : 'Return'}</button>
                     </form>
                 </td>`;
         } else {
@@ -213,12 +215,15 @@ function populateFleetStatusTable(cars) {
 // Function to process feedback and return a car from any status
 function processFeedback(event, carId, status) {
     event.preventDefault();
+
+    if (processingCarIds.has(carId)) return;
+
     const feedback = document.getElementById(`feedback-${carId}`).value;
     const button = event.target.querySelector('button');
 
+    processingCarIds.add(carId);
     button.disabled = true;
     button.classList.add('loading');
-    const originalText = button.textContent;
     button.textContent = 'Processing...';
 
     const statusLabels = {
@@ -233,6 +238,7 @@ function processFeedback(event, carId, status) {
         return response.text();
     })
     .then(data => {
+        processingCarIds.delete(carId);
         lastUpdatedCarId = carId;
         showNotification(`Car successfully returned from ${statusLabels[status]}`);
         loadAllCars();
@@ -240,9 +246,8 @@ function processFeedback(event, carId, status) {
     .catch(error => {
         console.error(`Error returning car from ${statusLabels[status]}:`, error);
         displayError(`Failed to process ${statusLabels[status]} return. Please try again.`);
-        button.disabled = false;
-        button.classList.remove('loading');
-        button.textContent = originalText;
+        processingCarIds.delete(carId);
+        loadAllCars();
     });
 }
 
@@ -418,16 +423,22 @@ async function loadPendingApprovals() {
             }
         }
         
-        // Only update modal content if modal is NOT open (prevents flashing)
-        if (!isModalOpen) {
+        // Always keep modal content in sync with pending approvals.
+        // Cards being decided are removed individually via animation in handleProposalDecision,
+        // so we only add cards that aren't already rendered to avoid disrupting ones in-flight.
+        if (isModalOpen) {
             const modalBody = document.getElementById('approval-modal-body');
             if (!proposals || proposals.length === 0) {
                 modalBody.innerHTML = '<p style="text-align: center; padding: 40px; color: #666;">No pending approvals at this time.</p>';
             } else {
-                modalBody.innerHTML = '';
+                const renderedIds = new Set(
+                    [...modalBody.querySelectorAll('.approval-card')].map(el => el.id)
+                );
                 proposals.forEach(proposal => {
-                    const card = createApprovalCard(proposal);
-                    modalBody.appendChild(card);
+                    if (!renderedIds.has(`approval-${proposal.id}`)) {
+                        const card = createApprovalCard(proposal);
+                        modalBody.appendChild(card);
+                    }
                 });
             }
         }

--- a/section-2/step-06/src/main/resources/META-INF/resources/js/app.js
+++ b/section-2/step-06/src/main/resources/META-INF/resources/js/app.js
@@ -7,6 +7,7 @@ let carsData = []; // Store the cars data globally for sorting
 let currentFilterText = '';
 let currentFilterField = 'all';
 let lastUpdatedCarId = null; // Track the last updated car for highlighting
+let processingCarIds = new Set(); // Track cars currently being processed
 
 // Wait for the DOM to be fully loaded
 document.addEventListener('DOMContentLoaded', function() {
@@ -186,12 +187,13 @@ function populateFleetStatusTable(cars) {
         // Build action cell based on status
         let actionCell = '';
         if (car.status === 'RENTED' || car.status === 'AT_CLEANING' || car.status === 'IN_MAINTENANCE') {
+            const isProcessing = processingCarIds.has(car.id);
             actionCell = `
                 <td>
                     <form onsubmit="processFeedback(event, ${car.id}, '${car.status}')">
-                        <input type="file" id="car-image-${car.id}" accept="image/*">
-                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback">
-                        <button type="submit" class="return-button">Return</button>
+                        <input type="file" id="car-image-${car.id}" accept="image/*" ${isProcessing ? 'disabled' : ''}>
+                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback" ${isProcessing ? 'disabled' : ''}>
+                        <button type="submit" class="return-button" ${isProcessing ? 'disabled' : ''}>${isProcessing ? 'Processing...' : 'Return'}</button>
                     </form>
                 </td>`;
         } else {
@@ -215,12 +217,15 @@ function populateFleetStatusTable(cars) {
 // Function to process feedback and return a car from any status
 function processFeedback(event, carId, status) {
     event.preventDefault();
+
+    if (processingCarIds.has(carId)) return;
+
     const feedback = document.getElementById(`feedback-${carId}`).value;
     const button = event.target.querySelector('button');
 
+    processingCarIds.add(carId);
     button.disabled = true;
     button.classList.add('loading');
-    const originalText = button.textContent;
     button.textContent = 'Processing...';
 
     const statusLabels = {
@@ -245,6 +250,7 @@ function processFeedback(event, carId, status) {
         return response.text();
     })
     .then(data => {
+        processingCarIds.delete(carId);
         lastUpdatedCarId = carId;
         showNotification(`Car successfully returned from ${statusLabels[status]}`);
         loadAllCars();
@@ -252,9 +258,8 @@ function processFeedback(event, carId, status) {
     .catch(error => {
         console.error(`Error returning car from ${statusLabels[status]}:`, error);
         displayError(`Failed to process ${statusLabels[status]} return. Please try again.`);
-        button.disabled = false;
-        button.classList.remove('loading');
-        button.textContent = originalText;
+        processingCarIds.delete(carId);
+        loadAllCars();
     });
 }
 
@@ -430,16 +435,22 @@ async function loadPendingApprovals() {
             }
         }
         
-        // Only update modal content if modal is NOT open (prevents flashing)
-        if (!isModalOpen) {
+        // Always keep modal content in sync with pending approvals.
+        // Cards being decided are removed individually via animation in handleProposalDecision,
+        // so we only add cards that aren't already rendered to avoid disrupting ones in-flight.
+        if (isModalOpen) {
             const modalBody = document.getElementById('approval-modal-body');
             if (!proposals || proposals.length === 0) {
                 modalBody.innerHTML = '<p style="text-align: center; padding: 40px; color: #666;">No pending approvals at this time.</p>';
             } else {
-                modalBody.innerHTML = '';
+                const renderedIds = new Set(
+                    [...modalBody.querySelectorAll('.approval-card')].map(el => el.id)
+                );
                 proposals.forEach(proposal => {
-                    const card = createApprovalCard(proposal);
-                    modalBody.appendChild(card);
+                    if (!renderedIds.has(`approval-${proposal.id}`)) {
+                        const card = createApprovalCard(proposal);
+                        modalBody.appendChild(card);
+                    }
                 });
             }
         }

--- a/section-2/step-07/multi-agent-system/src/main/resources/META-INF/resources/js/app.js
+++ b/section-2/step-07/multi-agent-system/src/main/resources/META-INF/resources/js/app.js
@@ -7,6 +7,7 @@ let carsData = []; // Store the cars data globally for sorting
 let currentFilterText = '';
 let currentFilterField = 'all';
 let lastUpdatedCarId = null; // Track the last updated car for highlighting
+let processingCarIds = new Set(); // Track cars currently being processed
 
 // Wait for the DOM to be fully loaded
 document.addEventListener('DOMContentLoaded', function() {
@@ -186,12 +187,13 @@ function populateFleetStatusTable(cars) {
         // Build action cell based on status
         let actionCell = '';
         if (car.status === 'RENTED' || car.status === 'AT_CLEANING' || car.status === 'IN_MAINTENANCE') {
+            const isProcessing = processingCarIds.has(car.id);
             actionCell = `
                 <td>
                     <form onsubmit="processFeedback(event, ${car.id}, '${car.status}')">
-                        <input type="file" id="car-image-${car.id}" accept="image/*">
-                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback">
-                        <button type="submit" class="return-button">Return</button>
+                        <input type="file" id="car-image-${car.id}" accept="image/*" ${isProcessing ? 'disabled' : ''}>
+                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback" ${isProcessing ? 'disabled' : ''}>
+                        <button type="submit" class="return-button" ${isProcessing ? 'disabled' : ''}>${isProcessing ? 'Processing...' : 'Return'}</button>
                     </form>
                 </td>`;
         } else {
@@ -215,12 +217,15 @@ function populateFleetStatusTable(cars) {
 // Function to process feedback and return a car from any status
 function processFeedback(event, carId, status) {
     event.preventDefault();
+
+    if (processingCarIds.has(carId)) return;
+
     const feedback = document.getElementById(`feedback-${carId}`).value;
     const button = event.target.querySelector('button');
 
+    processingCarIds.add(carId);
     button.disabled = true;
     button.classList.add('loading');
-    const originalText = button.textContent;
     button.textContent = 'Processing...';
 
     const statusLabels = {
@@ -245,6 +250,7 @@ function processFeedback(event, carId, status) {
         return response.text();
     })
     .then(data => {
+        processingCarIds.delete(carId);
         lastUpdatedCarId = carId;
         showNotification(`Car successfully returned from ${statusLabels[status]}`);
         loadAllCars();
@@ -252,9 +258,8 @@ function processFeedback(event, carId, status) {
     .catch(error => {
         console.error(`Error returning car from ${statusLabels[status]}:`, error);
         displayError(`Failed to process ${statusLabels[status]} return. Please try again.`);
-        button.disabled = false;
-        button.classList.remove('loading');
-        button.textContent = originalText;
+        processingCarIds.delete(carId);
+        loadAllCars();
     });
 }
 
@@ -429,17 +434,23 @@ async function loadPendingApprovals() {
                 closeApprovalModal();
             }
         }
-        
-        // Only update modal content if modal is NOT open (prevents flashing)
-        if (!isModalOpen) {
+
+        // Always keep modal content in sync with pending approvals.
+        // Cards being decided are removed individually via animation in handleProposalDecision,
+        // so we only add cards that aren't already rendered to avoid disrupting ones in-flight.
+        if (isModalOpen) {
             const modalBody = document.getElementById('approval-modal-body');
             if (!proposals || proposals.length === 0) {
                 modalBody.innerHTML = '<p style="text-align: center; padding: 40px; color: #666;">No pending approvals at this time.</p>';
             } else {
-                modalBody.innerHTML = '';
+                const renderedIds = new Set(
+                    [...modalBody.querySelectorAll('.approval-card')].map(el => el.id)
+                );
                 proposals.forEach(proposal => {
-                    const card = createApprovalCard(proposal);
-                    modalBody.appendChild(card);
+                    if (!renderedIds.has(`approval-${proposal.id}`)) {
+                        const card = createApprovalCard(proposal);
+                        modalBody.appendChild(card);
+                    }
                 });
             }
         }

--- a/section-2/step-08/multi-agent-system/src/main/resources/META-INF/resources/js/app.js
+++ b/section-2/step-08/multi-agent-system/src/main/resources/META-INF/resources/js/app.js
@@ -7,6 +7,7 @@ let carsData = []; // Store the cars data globally for sorting
 let currentFilterText = '';
 let currentFilterField = 'all';
 let lastUpdatedCarId = null; // Track the last updated car for highlighting
+let processingCarIds = new Set(); // Track cars currently being processed
 
 // Wait for the DOM to be fully loaded
 document.addEventListener('DOMContentLoaded', function() {
@@ -186,12 +187,13 @@ function populateFleetStatusTable(cars) {
         // Build action cell based on status
         let actionCell = '';
         if (car.status === 'RENTED' || car.status === 'AT_CLEANING' || car.status === 'IN_MAINTENANCE') {
+            const isProcessing = processingCarIds.has(car.id);
             actionCell = `
                 <td>
                     <form onsubmit="processFeedback(event, ${car.id}, '${car.status}')">
-                        <input type="file" id="car-image-${car.id}" accept="image/*">
-                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback">
-                        <button type="submit" class="return-button">Return</button>
+                        <input type="file" id="car-image-${car.id}" accept="image/*" ${isProcessing ? 'disabled' : ''}>
+                        <input type="text" class="feedback-input" id="feedback-${car.id}" placeholder="Enter feedback" ${isProcessing ? 'disabled' : ''}>
+                        <button type="submit" class="return-button" ${isProcessing ? 'disabled' : ''}>${isProcessing ? 'Processing...' : 'Return'}</button>
                     </form>
                 </td>`;
         } else {
@@ -215,12 +217,15 @@ function populateFleetStatusTable(cars) {
 // Function to process feedback and return a car from any status
 function processFeedback(event, carId, status) {
     event.preventDefault();
+
+    if (processingCarIds.has(carId)) return;
+
     const feedback = document.getElementById(`feedback-${carId}`).value;
     const button = event.target.querySelector('button');
 
+    processingCarIds.add(carId);
     button.disabled = true;
     button.classList.add('loading');
-    const originalText = button.textContent;
     button.textContent = 'Processing...';
 
     const statusLabels = {
@@ -245,6 +250,7 @@ function processFeedback(event, carId, status) {
         return response.text();
     })
     .then(data => {
+        processingCarIds.delete(carId);
         lastUpdatedCarId = carId;
         showNotification(`Car successfully returned from ${statusLabels[status]}`);
         loadAllCars();
@@ -252,9 +258,8 @@ function processFeedback(event, carId, status) {
     .catch(error => {
         console.error(`Error returning car from ${statusLabels[status]}:`, error);
         displayError(`Failed to process ${statusLabels[status]} return. Please try again.`);
-        button.disabled = false;
-        button.classList.remove('loading');
-        button.textContent = originalText;
+        processingCarIds.delete(carId);
+        loadAllCars();
     });
 }
 
@@ -430,16 +435,22 @@ async function loadPendingApprovals() {
             }
         }
         
-        // Only update modal content if modal is NOT open (prevents flashing)
-        if (!isModalOpen) {
+        // Always keep modal content in sync with pending approvals.
+        // Cards being decided are removed individually via animation in handleProposalDecision,
+        // so we only add cards that aren't already rendered to avoid disrupting ones in-flight.
+        if (isModalOpen) {
             const modalBody = document.getElementById('approval-modal-body');
             if (!proposals || proposals.length === 0) {
                 modalBody.innerHTML = '<p style="text-align: center; padding: 40px; color: #666;">No pending approvals at this time.</p>';
             } else {
-                modalBody.innerHTML = '';
+                const renderedIds = new Set(
+                    [...modalBody.querySelectorAll('.approval-card')].map(el => el.id)
+                );
                 proposals.forEach(proposal => {
-                    const card = createApprovalCard(proposal);
-                    modalBody.appendChild(card);
+                    if (!renderedIds.has(`approval-${proposal.id}`)) {
+                        const card = createApprovalCard(proposal);
+                        modalBody.appendChild(card);
+                    }
                 });
             }
         }


### PR DESCRIPTION
## Problem

Two UX bugs affected all Section 2 steps that have the fleet management UI.

### 1. Concurrent return button re-enabled on table refresh (steps 01–08)

When two car returns were in-flight simultaneously, the first one completing triggered `loadAllCars()`, which re-rendered the entire table from fresh server data. Since the second car was still `RENTED` on the server at that point, its row was recreated with a brand-new enabled button — silently discarding the in-progress state. The user saw the button re-activate and had no feedback that the request was still running in the background.

### 2. Blank approval modal after deciding the first of multiple proposals (steps 05–08)

The `loadPendingApprovals` poller had a guard `if (!isModalOpen)` intended to prevent the modal from flashing during background polling. However, when the user decided a proposal (which removed its card via fade animation and called `loadPendingApprovals()`), the same guard blocked the update. If a second approval was pending, the modal was left showing only its orange header with an empty body.

## Fix

**Fix 1 — `processingCarIds` Set (all steps)**

Added a module-level `Set` that tracks car IDs with in-flight requests. `populateFleetStatusTable` checks the Set when building each row and renders the button pre-disabled with "Processing..." text if the car is in flight. The Set is cleared on success or error, followed by `loadAllCars()`. An early-return guard in `processFeedback` also prevents double-submitting the same car.

**Fix 2 — modal ID-diff sync (steps 05–08)**

Flipped the modal guard from `if (!isModalOpen)` to `if (isModalOpen)`. Instead of blanket-replacing `innerHTML` on each poll (which would flash and cancel ongoing CSS animations), the poller now diffs by element ID — it only appends cards whose `approval-{id}` element is not already present in the modal body. Individual card removal on decision is unchanged.