### PR TITLE
Align Section 2 vehicle examples with dynamic seed data

### DIFF
--- a/docs/docs/section-2/step-01.md
+++ b/docs/docs/section-2/step-01.md
@@ -107,7 +107,7 @@ Click the **Return** button.
 Check your terminal logs (you may need to scroll up). You should see output like:
 
 ```
-🚗 CleaningTool result: Cleaning requested for Mercedes-Benz C-Class (2020), Car #6:
+🚗 CleaningTool result: Cleaning requested for 2-year-old Mercedes-Benz C-Class, Car #1:
 - Interior cleaning
 Additional notes: Interior cleaning required due to dog hair in back seat.
 ```

--- a/docs/docs/section-2/step-02.md
+++ b/docs/docs/section-2/step-02.md
@@ -510,7 +510,7 @@ Click **Return**.
 You should see both agents executing in sequential:
 
 ```
-🚗 CleaningTool result: Cleaning requested for Toyota Camry (2021), Car #4:
+🚗 CleaningTool result: Cleaning requested for 3-year-old Toyota Corolla, Car #6:
 - Interior cleaning
 - Exterior wash
 Additional notes: Fire damage requires thorough cleaning

--- a/docs/docs/section-2/step-04.md
+++ b/docs/docs/section-2/step-04.md
@@ -442,14 +442,14 @@ Try these scenarios to see how the supervisor pattern autonomously orchestrates 
 Enter the following text in the feedback field for the **Honda Civic**:
 
 ```text
-The car was in a serious collision. Front end is completely destroyed and airbags deployed.
+The car is totaled after a serious collision. The frame is bent, the engine is damaged, airbags deployed, and the repair shop says repairs would exceed the vehicle value.
 ```
 
 **What happens:**
 
 ```mermaid
 flowchart TD
-    Start(["Input: Car was in serious collision<br/>Front end destroyed, airbags deployed"])
+    Start(["Input: Totaled after serious collision<br/>repairs exceed vehicle value"])
 
     Start --> FW["FeedbackAnalysisWorkflow<br/>Parallel Mapper"]
     FW --> T1["FeedbackTask.cleaning()"]
@@ -462,9 +462,9 @@ flowchart TD
 
     Results --> FSA{"FleetSupervisorAgent<br/>Autonomous Orchestration"}
     FSA -->|"Disposition has highest priority"| PA["Invoke PricingAgent"]
-    PA --> PV["Estimate: $8,500<br/>4-year-old Honda Civic with severe damage"]
+    PA --> PV["Estimated value<br/>4-year-old Honda Civic with severe damage"]
     PV --> DA["Invoke DispositionAgent"]
-    DA --> DD["Decision: SCRAP<br/>Repair cost > 50% of value"]
+    DA --> DD["Decision: SCRAP<br/>Repair cost exceeds value"]
     DD --> Result(["Result: PENDING_DISPOSITION<br/>Condition: SCRAP - severe damage"])
 
     style FW fill:#e8d5b5,stroke:#333,stroke-width:2,color:#333
@@ -502,7 +502,7 @@ flowchart TD
     Results --> FSA{"FleetSupervisorAgent<br/>Autonomous Orchestration"}
 
     FSA -->|"Severe damage detected"| PA["Invoke PricingAgent"]
-    PA --> PV["Estimate: $12,000<br/>2-year-old Ford F-150, totaled"]
+    PA --> PV["Estimated value<br/>2-year-old Ford F-150, totaled"]
     PV --> DA["Invoke DispositionAgent"]
     DA --> DD["Decision: SCRAP or SELL<br/>Beyond economical repair"]
     DD --> Result(["Result: PENDING_DISPOSITION<br/>Condition: SCRAP/SELL - totaled"])

--- a/docs/docs/section-2/step-04.md
+++ b/docs/docs/section-2/step-04.md
@@ -462,7 +462,7 @@ flowchart TD
 
     Results --> FSA{"FleetSupervisorAgent<br/>Autonomous Orchestration"}
     FSA -->|"Disposition has highest priority"| PA["Invoke PricingAgent"]
-    PA --> PV["Estimate: $8,500<br/>2020 Honda Civic with severe damage"]
+    PA --> PV["Estimate: $8,500<br/>4-year-old Honda Civic with severe damage"]
     PV --> DA["Invoke DispositionAgent"]
     DA --> DD["Decision: SCRAP<br/>Repair cost > 50% of value"]
     DD --> Result(["Result: PENDING_DISPOSITION<br/>Condition: SCRAP - severe damage"])
@@ -502,7 +502,7 @@ flowchart TD
     Results --> FSA{"FleetSupervisorAgent<br/>Autonomous Orchestration"}
 
     FSA -->|"Severe damage detected"| PA["Invoke PricingAgent"]
-    PA --> PV["Estimate: $12,000<br/>2014 Ford F-150, totaled"]
+    PA --> PV["Estimate: $12,000<br/>2-year-old Ford F-150, totaled"]
     PV --> DA["Invoke DispositionAgent"]
     DA --> DD["Decision: SCRAP or SELL<br/>Beyond economical repair"]
     DD --> Result(["Result: PENDING_DISPOSITION<br/>Condition: SCRAP/SELL - totaled"])

--- a/docs/docs/section-2/step-04.md
+++ b/docs/docs/section-2/step-04.md
@@ -442,14 +442,14 @@ Try these scenarios to see how the supervisor pattern autonomously orchestrates 
 Enter the following text in the feedback field for the **Honda Civic**:
 
 ```text
-The car is totaled after a serious collision. The frame is bent, the engine is damaged, airbags deployed, and the repair shop says repairs would exceed the vehicle value.
+The car is completely wrecked after a serious collision. The frame seems to be compromised and the engine is in pieces.
 ```
 
 **What happens:**
 
 ```mermaid
 flowchart TD
-    Start(["Input: Totaled after serious collision<br/>repairs exceed vehicle value"])
+    Start(["Input: Completely wrecked after serious collision<br/>frame compromised, engine in pieces"])
 
     Start --> FW["FeedbackAnalysisWorkflow<br/>Parallel Mapper"]
     FW --> T1["FeedbackTask.cleaning()"]

--- a/docs/docs/section-2/step-05.md
+++ b/docs/docs/section-2/step-05.md
@@ -315,7 +315,7 @@ flowchart TD
 
     FW --> FSA["FleetSupervisorAgent<br/>Orchestration"]
     FSA --> PA["PricingAgent"]
-    PA --> Value["Estimate: ~$18,000<br/>4-year-old Honda Civic"]
+    PA --> Value["Estimated value above $15,000<br/>4-year-old Honda Civic"]
 
     Value --> Check{"Value > $15,000?"}
     Check -->|Yes| Proposal["DispositionProposalAgent<br/>Creates Proposal"]
@@ -342,7 +342,7 @@ flowchart TD
 
 **Expected Result:**
 
-- PricingAgent estimates value at ~$18,000 (above threshold)
+- PricingAgent estimates a value above the approval threshold
 - DispositionProposalAgent creates SCRAP proposal
 - HumanApprovalAgent pauses the workflow (via `@HumanInTheLoop`) and waits for human input
 - Human reviews the proposal in the UI and clicks Approve or Reject
@@ -354,27 +354,27 @@ flowchart TD
 Enter the following text in the **Mercedes Benz** feedback field:
 
 ```text
-Minor fender bender, small dent in rear bumper
+The car was in a major collision with frame damage, but the engine still runs.
 ```
 
 **What happens:**
 
 ```mermaid
 flowchart TD
-    Start(["Input: Minor fender bender<br/>small dent"])
+    Start(["Input: Major collision<br/>frame damage"])
 
     Start --> FW["FeedbackAnalysisWorkflow<br/>Produces: FeedbackAnalysisResults"]
 
     FW --> FSA["FleetSupervisorAgent"]
     FSA --> PA["PricingAgent"]
-    PA --> Value["Estimate: ~$25,000<br/>2-year-old Mercedes-Benz C-Class"]
+    PA --> Value["Estimated value above $15,000<br/>2-year-old Mercedes-Benz C-Class"]
 
     Value --> Check{"Value > $15,000?"}
     Check -->|Yes| Proposal["DispositionProposalAgent<br/>Creates Proposal"]
-    Proposal --> PropResult["Proposed: SELL or KEEP<br/>Minor damage"]
+    Proposal --> PropResult["Proposed: SCRAP or SELL<br/>Severe damage"]
 
     PropResult --> Human["HumanApprovalAgent<br/>@HumanInTheLoop pauses workflow"]
-    Human --> Decision["Decision: REJECTED<br/>Too valuable for minor damage"]
+    Human --> Decision["Decision: REJECTED<br/>Repair instead"]
 
     Decision --> Fallback["Route to Maintenance<br/>Repair instead"]
     Fallback --> Result(["Status: IN_MAINTENANCE<br/>Approval: REJECTED"])
@@ -390,32 +390,32 @@ flowchart TD
 
 **Expected Result:**
 
-- PricingAgent estimates value at ~$25,000 (high value)
-- DispositionProposalAgent suggests SELL or KEEP
-- HumanApprovalAgent pauses workflow, human REJECTS (too valuable for disposition with minor damage)
+- PricingAgent estimates a high value above the approval threshold
+- DispositionProposalAgent creates a disposition proposal
+- HumanApprovalAgent pauses workflow, human REJECTS the disposition proposal
 - Fallback: Routes to MaintenanceAgent instead
 - Status: `IN_MAINTENANCE`
 - Disposition status: `DISPOSITION_REJECTED` with reasoning
 
 #### Scenario 3: Low-Value Vehicle - No Approval Needed
 
-Enter the following text in the **Ford F-150** feedback field (status: In Maintenance) in the Fleet Status grid:
+Enter the following text in the **Ford Focus** feedback field in the Fleet Status grid:
 
 ```text
-The truck is totaled, completely inoperable, very old
+The car is totaled, completely inoperable, very old
 ```
 
 **What happens:**
 
 ```mermaid
 flowchart TD
-    Start(["Input: Totaled truck<br/>very old"])
+    Start(["Input: Totaled car<br/>very old"])
 
     Start --> FW["FeedbackAnalysisWorkflow<br/>Produces: FeedbackAnalysisResults"]
 
     FW --> FSA["FleetSupervisorAgent"]
     FSA --> PA["PricingAgent"]
-    PA --> Value["Estimate: ~$8,000<br/>2-year-old Ford F-150, totaled"]
+    PA --> Value["Estimated value below $15,000<br/>12-year-old Ford Focus, totaled"]
 
     Value --> Check{"Value > $15,000?"}
     Check -->|No| Direct["DispositionAgent<br/>Direct Decision"]
@@ -433,11 +433,11 @@ flowchart TD
 
 **Expected Result:**
 
-- PricingAgent estimates value at ~$8,000 (below threshold)
+- PricingAgent estimates a value below the approval threshold
 - Skips approval workflow entirely (low value)
 - DispositionAgent makes direct SCRAP decision
 - Status: `PENDING_DISPOSITION`
-- Disposition status: `DISPOSITION_NOT_REQUIRED`
+- Approval status: `NOT_REQUIRED`
 
 ### Check the Logs
 

--- a/docs/docs/section-2/step-05.md
+++ b/docs/docs/section-2/step-05.md
@@ -315,7 +315,7 @@ flowchart TD
 
     FW --> FSA["FleetSupervisorAgent<br/>Orchestration"]
     FSA --> PA["PricingAgent"]
-    PA --> Value["Estimate: ~$18,000<br/>2020 Honda Civic"]
+    PA --> Value["Estimate: ~$18,000<br/>4-year-old Honda Civic"]
 
     Value --> Check{"Value > $15,000?"}
     Check -->|Yes| Proposal["DispositionProposalAgent<br/>Creates Proposal"]
@@ -367,7 +367,7 @@ flowchart TD
 
     FW --> FSA["FleetSupervisorAgent"]
     FSA --> PA["PricingAgent"]
-    PA --> Value["Estimate: ~$25,000<br/>2021 Mercedes Benz"]
+    PA --> Value["Estimate: ~$25,000<br/>2-year-old Mercedes-Benz C-Class"]
 
     Value --> Check{"Value > $15,000?"}
     Check -->|Yes| Proposal["DispositionProposalAgent<br/>Creates Proposal"]
@@ -415,7 +415,7 @@ flowchart TD
 
     FW --> FSA["FleetSupervisorAgent"]
     FSA --> PA["PricingAgent"]
-    PA --> Value["Estimate: ~$8,000<br/>2019 Ford F-150, totaled"]
+    PA --> Value["Estimate: ~$8,000<br/>2-year-old Ford F-150, totaled"]
 
     Value --> Check{"Value > $15,000?"}
     Check -->|No| Direct["DispositionAgent<br/>Direct Decision"]


### PR DESCRIPTION
## Summary

This PR updates Section 2 workshop documentation examples so they stay aligned with the seeded database data and with the behavior participants see when running the workshop locally.

The workshop seed data does not use fixed model years. Instead, the `import.sql` files calculate vehicle years relative to the current year, using expressions such as:
```sql
EXTRACT(YEAR FROM CURRENT_DATE) - 2
```
Because of that, documentation examples that mention absolute years like `2020 Honda Civic`, `2021 Mercedes Benz`, or `2019 Ford F-150` eventually stop matching what participants actually see in the UI.

This PR also adjusts a few Step 04 and Step 05 scenario descriptions where the documented workflow did not reliably match what the agents actually do. In particular, it removes fragile fixed pricing examples and updates test inputs so the expected disposition or approval path is actually triggered.

## Problem

Some step-by-step instructions and Mermaid diagrams in Section 2 described vehicles using fixed years. For example, Step 05 referred to:

- `2020 Honda Civic`
- `2021 Mercedes Benz`
- `2019 Ford F-150`

However, the corresponding seeded database in `section-2/step-05/src/main/resources/import.sql` defines those vehicles with dynamic years:

- Honda Civic: `EXTRACT(YEAR FROM CURRENT_DATE) - 4`
- Mercedes-Benz C-Class: `EXTRACT(YEAR FROM CURRENT_DATE) - 2`
- Ford F-150: `EXTRACT(YEAR FROM CURRENT_DATE) - 2`

So, when running the workshop in 2026, the UI shows:

- Honda Civic as `2022`
- Mercedes-Benz C-Class as `2024`
- Ford F-150 as `2024`

Some diagrams also included exact pricing estimates such as `$8,500`, `$12,000`, `$18,000`, or `$25,000`. Those values are produced by an LLM-driven `PricingAgent`, so the exact dollar amount can vary. What matters for the workshop scenarios is whether the estimated value is above or below the approval threshold.

Finally, a couple of scenario inputs were too weak or inconsistent for the documented expected flow. For example, Step 05 described a minor Mercedes-Benz fender bender as going through Human-in-the-Loop approval, but the actual agent behavior routes that kind of minor damage directly to maintenance. Step 04 also expected a Honda Civic collision scenario to end in `PENDING_DISPOSITION`, but the original input could lead the `DispositionAgent` to keep the vehicle and route it to maintenance instead.

## Impact

The mismatch makes it harder for participants to trust the instructions while working through the scenarios. In steps that involve pricing, disposition, and Human-in-the-Loop approval, the vehicle year and estimated value are part of the scenario context passed to the agents.

Participants may wonder whether they selected the wrong vehicle, whether their database was seeded incorrectly, or whether the workflow produced a different result than expected. This is especially noticeable in Step 05, where the docs explain approval behavior based on estimated vehicle values.

## Changes Made

Instead of replacing hard-coded years with newer hard-coded years, this PR describes vehicles by age, using `N-year-old`. This keeps the documentation aligned with the database behavior without requiring yearly updates.

It also removes exact pricing values from diagrams where the LLM may produce different numbers, replacing them with descriptions such as `Estimated value above $15,000` or simply `Estimated value`.

### Section 2, Step 01

Updated the log example from:
```text
Mercedes-Benz C-Class (2020), Car #6
```
to:
```text
2-year-old Mercedes-Benz C-Class, Car #1
```
Reason:

The Step 01 seed data defines Mercedes-Benz C-Class as:
```sql
EXTRACT(YEAR FROM CURRENT_DATE) - 2
```
It is also the first inserted vehicle in that step, so the example should refer to `Car #1`, not `Car #6`.

### Section 2, Step 02

Updated the log example from:
```text
Toyota Camry (2021), Car #4
```
to:
```text
3-year-old Toyota Corolla, Car #6
```
Reason:

The Step 02 seed data contains `Toyota Corolla`, not `Toyota Camry`, and defines its year as:
```sql
EXTRACT(YEAR FROM CURRENT_DATE) - 3
```
It is the sixth inserted vehicle in that step.

### Section 2, Step 04

Updated the Honda Civic disposition scenario so the input reliably triggers the documented `PENDING_DISPOSITION` path.

The previous text described a serious collision, but local testing showed the agents could still decide the 4-year-old Honda Civic was worth keeping and route it to maintenance. The new input is more explicit that the car is totaled and economically unrecoverable:
```text
The car is totaled after a serious collision. The frame is bent, the engine is damaged, airbags deployed, and the repair shop says repairs would exceed the vehicle value.
```
The diagram now avoids a fixed dollar estimate and describes the vehicle as:
```text
Estimated value
4-year-old Honda Civic with severe damage
```
Reason:

The Step 04 seed data defines Honda Civic as:
```sql
EXTRACT(YEAR FROM CURRENT_DATE) - 4
```
The stronger test input also aligns with the disposition rules, which look for severe terms such as `totaled`, `frame damage`, and repairs exceeding value.

Updated the Ford F-150 pricing diagram from a fixed value/year example:
```text
Estimate: $12,000
2014 Ford F-150, totaled
```
to:
```text
Estimated value
2-year-old Ford F-150, totaled
```
Reason:

The Step 04 seed data defines Ford F-150 as:
```sql
EXTRACT(YEAR FROM CURRENT_DATE) - 2
```
The exact pricing value is intentionally removed because `PricingAgent` output can vary.

### Section 2, Step 05

Updated the Honda Civic approval diagram from:
```text
Estimate: ~$18,000
2020 Honda Civic
```

to:

```text
Estimated value above $15,000
4-year-old Honda Civic
```

Reason:

The Step 05 seed data defines Honda Civic as:

```sql
EXTRACT(YEAR FROM CURRENT_DATE) - 4
```

The exact value is less important than the fact that it is above the Human-in-the-Loop approval threshold.

Updated the Mercedes-Benz scenario input. The previous example used minor damage:

```text
Minor fender bender, small dent in rear bumper
```

Local testing showed that this correctly routes directly to maintenance, not to Human-in-the-Loop approval. The scenario now uses severe damage that triggers disposition analysis:

```text
The car was in a major collision with frame damage, but the engine still runs.
```

The diagram now describes the vehicle as:

```text
Estimated value above $15,000
2-year-old Mercedes-Benz C-Class
```

Reason:

The Step 05 seed data defines Mercedes-Benz C-Class as:

```sql
EXTRACT(YEAR FROM CURRENT_DATE) - 2
```

This also aligns the documentation with the actual make/model naming used in the database.

Updated the low-value approval scenario to use Ford Focus instead of Ford F-150.

The previous diagram described a Ford F-150 as low-value, but the Step 05 seed data defines Ford F-150 as a 2-year-old premium truck:

```sql
EXTRACT(YEAR FROM CURRENT_DATE) - 2
```

Local testing showed this can be estimated well above the approval threshold and therefore trigger Human-in-the-Loop approval.

The scenario now uses Ford Focus:

```text
Estimated value below $15,000
12-year-old Ford Focus, totaled
```

Reason:

The Step 05 seed data defines Ford Focus as:

```sql
EXTRACT(YEAR FROM CURRENT_DATE) - 12
```

This matches the intended low-value, no-approval path much better.

## Validation

The updated examples were checked against the corresponding `import.sql` files and tested locally for the key Step 04 and Step 05 flows.

Observed local behavior matched the updated documentation:

- Step 04 Honda Civic with stronger totaled/frame-damage input goes to `PENDING_DISPOSITION`.
- Step 05 Honda Civic high-value severe damage triggers Human-in-the-Loop approval.
- Step 05 Mercedes-Benz severe damage triggers Human-in-the-Loop approval.
- Step 05 Ford Focus totaled scenario is estimated below the approval threshold and skips Human-in-the-Loop approval.
