### PR TITLE
Fix Section 2 Step 7 disposition examples for dynamic model selection

### DIFF
--- a/docs/docs/section-2/step-07.md
+++ b/docs/docs/section-2/step-07.md
@@ -141,24 +141,24 @@ cd section-2/step-07
 
 3. Open [http://localhost:8080](http://localhost:8080){target="_blank"}
 
-### Test with a Low-Value Vehicle
+### Test with a Standard-Value Vehicle
 
-Find a car in the Fleet Status grid and enter feedback describing damage to a lower-value vehicle:
+Find the Toyota Corolla in the Fleet Status grid and enter feedback describing severe damage:
 
 ```text
-Old economy car, high mileage, paint is faded and the engine makes a rattling noise
+The car was involved in a severe collision, with heavy front-end damage, rear bumper damage, and possible frame damage. It may not be safe to drive.
 ```
 
 Click **Return**.
 
-The `DispositionProposalAgent` will use the default `gpt-4o-mini` model. Check the application logs — you should see the disposition proposal generated without the advanced model being invoked.
+This feedback is intentionally severe so the disposition analysis is activated. The Toyota Corolla should still be below the $30,000 advanced-model threshold, so the `DispositionProposalAgent` will use the default `gpt-4o-mini` model. Check the application logs. You should see the disposition proposal generated without the advanced model being invoked.
 
 ### Test with a High-Value Vehicle
 
-Now try a scenario where the PricingAgent estimates a value above $30,000. Enter feedback for a newer, more valuable car:
+Now try a scenario where the PricingAgent estimates a value above $30,000. Find the Mercedes-Benz C-Class in the Fleet Status grid and enter feedback describing severe damage:
 
 ```text
-Minor cosmetic scratch on driver door, otherwise in excellent condition
+The car was involved in a severe multi-car rear-end collision, with heavy damage to both the front and rear bumpers and possible structural damage.
 ```
 
 Click **Return**.

--- a/docs/docs/section-2/step-07.md
+++ b/docs/docs/section-2/step-07.md
@@ -143,7 +143,7 @@ cd section-2/step-07
 
 ### Test with a Standard-Value Vehicle
 
-Find the Toyota Corolla in the Fleet Status grid and enter feedback describing severe damage:
+Find the Honda Civic in the Fleet Status grid and enter feedback describing severe damage:
 
 ```text
 The car was involved in a severe collision, with heavy front-end damage, rear bumper damage, and possible frame damage. It may not be safe to drive.
@@ -151,7 +151,7 @@ The car was involved in a severe collision, with heavy front-end damage, rear bu
 
 Click **Return**.
 
-This feedback is intentionally severe so the disposition analysis is activated. The Toyota Corolla should still be below the $30,000 advanced-model threshold, so the `DispositionProposalAgent` will use the default `gpt-4o-mini` model. Check the application logs. You should see the disposition proposal generated without the advanced model being invoked.
+This feedback is intentionally severe so the disposition analysis is activated. The Honda Civic should still be below the $30,000 advanced-model threshold, so the `DispositionProposalAgent` will use the default `gpt-4o-mini` model. Check the application logs. You should see the disposition proposal generated without the advanced model being invoked.
 
 ### Test with a High-Value Vehicle
 

--- a/section-2/step-07/src/main/resources/import.sql
+++ b/section-2/step-07/src/main/resources/import.sql
@@ -21,6 +21,5 @@ INSERT INTO car_info (id, make, model, year, condition, status) VALUES
     
     -- Regular cars for testing cleaning/maintenance only
     (nextval('car_info_id_seq'), 'Toyota', 'Corolla', EXTRACT(YEAR FROM CURRENT_DATE) - 3, 'Like new, no issues', 'RENTED'),
-    (nextval('car_info_id_seq'), 'Honda', 'Civic', EXTRACT(YEAR FROM CURRENT_DATE) - 4, 'Good condition, minor wear and tear', 'RENTED'),
+    (nextval('car_info_id_seq'), 'Honda', 'Civic', EXTRACT(YEAR FROM CURRENT_DATE) - 8, 'Good condition, minor wear and tear', 'RENTED'),
     (nextval('car_info_id_seq'), 'Ford', 'F-150', EXTRACT(YEAR FROM CURRENT_DATE) - 2, 'Small scratch on rear bumper', 'IN_MAINTENANCE');
-


### PR DESCRIPTION
## Summary

This PR updates the Section 2 Step 7 dynamic model selection examples so the documented test scenarios actually exercise the intended workflow paths.

The previous examples used feedback that did not reliably trigger `DISPOSITION_REQUIRED`, so the workflow could stop before reaching `PricingAgent` and `DispositionProposalAgent`. This made it difficult to observe dynamic model selection in practice.

The updated examples use severe damage feedback that activates disposition analysis and routes the workflow through `DispositionProposalAgent`.

## Changes

- Replaces the standard/default model example with a Honda Civic scenario.
- Keeps severe collision feedback so disposition analysis is triggered.
- Updates the Honda Civic seed data to make the vehicle older, producing a standard-value estimate below the `$30,000` advanced-model threshold.
- Keeps the Mercedes-Benz C-Class as the high-value example for the advanced model path.

## Validation

Validated locally with Section 2 Step 07 running on `localhost:8080`.

Honda Civic standard-value scenario:

```text
DISPOSITION_REQUIRED
Estimated Value: $24,000
createDispositionProposal called
```

This exercises the default model path because `$24,000` is above the supervisor's `$15,000` proposal threshold but below the `DynamicModelSelector` `$30,000` advanced-model threshold.

Mercedes-Benz C-Class high-value scenario:

```text
DISPOSITION_REQUIRED
Estimated Value: $43,000
createDispositionProposal called
```

This exercises the advanced model path because `$43,000` is above the `$30,000` threshold.

## Notes

The supervisor can still invoke `processDisposition` multiple times after reaching the disposition path. That behavior is tracked separately in issue #406 and is not addressed by this PR.